### PR TITLE
Install git and mercurial

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ hello
 
 ## Choosing golang version
 This repo is hardcoded to use 1.4 although this can easily be changed after cloning. If you want to use another version simply
-change the `$version` parameter in `manifests/init.pp`. The version string is taken from the
+set the `$version` parameter when calling the class. The version string is taken from the
 [golang downloads list](http://golang.org/dl/). Once changed you can either call `vagrant up` if you
 haven't already setup the vagrant box or `vagrant provision` if the machine is already up.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,3 +1,15 @@
-class { "golang":
-  version => "1.4"
+stage { "prepare":
+  before => Stage["main"],
+}
+
+class setup {
+  exec { "update-aptitude":
+    command => "/usr/bin/apt-get update -y",
+  }
+}
+
+class {
+  "setup":
+    stage => prepare;
+  "golang":;
 }

--- a/modules/golang/manifests/init.pp
+++ b/modules/golang/manifests/init.pp
@@ -26,4 +26,16 @@ class golang ( $version = "1.4" ) {
     unless  => "/bin/grep -q GOPATH /home/vagrant/.profile ; /usr/bin/test $? -eq 0"
   }
 
+  if ! defined(Package["git"]) {
+    package { "git":
+      ensure => present,
+    }
+  }
+
+  if ! defined(Package["mercurial"]) {
+    package { "mercurial":
+      ensure => present,
+    }
+  }
+
 }


### PR DESCRIPTION
To make "go get" work in most cases you need either git or mercurial installed to clone the dependencies.

Now the golang class will install these but the requirement to update aptitude (on debian based machines) is not a concern for the golang class and so is handled outside of the class.

@sqreept Can you give this a try and see if this does what you want?

This solves both https://github.com/dcoxall/vagrant-golang/pull/6 and https://github.com/dcoxall/vagrant-golang/pull/5 whilst making an attempt at not being tied directly to debian (although there is still work to do to achieve this 100%)
