### PR TITLE
better GOPATH location

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,3 +10,8 @@ Vagrant::Config.run do |config|
     puppet.manifest_file      = "init.pp"
   end
 end
+
+Vagrant.configure("2") do |config|
+  # other config here
+  config.vm.synced_folder ".", "/home/vagrant/go"
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,8 +2,8 @@
 # vi: set ft=ruby :
 
 Vagrant::Config.run do |config|
-  config.vm.box = "debian-607-x64-vbox4210"
-  config.vm.box_url = "http://puppet-vagrant-boxes.puppetlabs.com/debian-607-x64-vbox4210.box"
+  config.vm.box = "precise64"
+  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
   config.vm.provision :puppet do |puppet|
     puppet.module_path      = "modules"
     puppet.manifests_path  = "manifests"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,5 +13,5 @@ end
 
 Vagrant.configure("2") do |config|
   # other config here
-  config.vm.synced_folder ".", "/home/vagrant/go/src/go-project"
+  config.vm.synced_folder ".", "/home/vagrant/go/src/#{File.basename(Dir.getwd)}"
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,5 +13,5 @@ end
 
 Vagrant.configure("2") do |config|
   # other config here
-  config.vm.synced_folder ".", "/home/vagrant/go"
+  config.vm.synced_folder ".", "/home/vagrant/go/src/go-project"
 end

--- a/modules/golang/manifests/init.pp
+++ b/modules/golang/manifests/init.pp
@@ -22,7 +22,7 @@ class golang ( $version = "1.4.1" ) {
   }
 
   exec { "setup-workspace":
-    command => "/bin/echo 'export GOPATH=/vagrant' >> /home/vagrant/.profile",
+    command => "/bin/echo 'export GOPATH=/home/vagrant/go' >> /home/vagrant/.profile",
     unless  => "/bin/grep -q GOPATH /home/vagrant/.profile ; /usr/bin/test $? -eq 0"
   }
 


### PR DESCRIPTION
The GOPATH location should not pollute the project folder. It's better to locate all the go modules directly inside the `/home/vagrant/go` folder