### PR TITLE
Update Go version to 1.5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Clone or copy the repo and do the following:
 
 ## Choosing golang version
 
-This repo is hardcoded to use 1.4.1 although this can easily be changed after
+This repo is hardcoded to use 1.5.3 although this can easily be changed after
 cloning. If you want to use another version simply set the `$version` parameter
 when calling the class. The version string is taken from the
 [golang downloads list](http://golang.org/dl/). Once changed you can either call

--- a/modules/golang/manifests/init.pp
+++ b/modules/golang/manifests/init.pp
@@ -1,4 +1,4 @@
-class golang ( $version = "1.4.1" ) {
+class golang ( $version = "1.5.3" ) {
 
   exec { "download-golang":
     command => "/usr/bin/wget --no-check-certificate -O /usr/local/src/go$version.linux-amd64.tar.gz http://golang.org/dl/go$version.linux-amd64.tar.gz",


### PR DESCRIPTION
Updated to the latest go version to date (1.5.3) in the init.pp. Tested on my machine.

## How to Test

```
$ vagrant up
$ vagrant ssh
$ go version
$ go env
```
## Expected output 
`go version` should output `go version go1.5.3 linux/amd64`.